### PR TITLE
Fix timezone related issues when displaying rides

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -4,7 +4,7 @@ import { Ride } from '../typings/ride.js'
 import RideManager from './rideManager.js'
 import { getRideInfo, parseFieldsFromMessage, setRideDateAndTime } from './utils/bot.js'
 import { adminUsers } from './utils/const.js'
-import { getCurrentTime, sleep, validateTimeFormat } from './utils/date.js'
+import { sleep, validateTimeFormat } from './utils/date.js'
 import {
   createFullRideMessage,
   getHelpMessage,
@@ -34,12 +34,10 @@ tgBot.on('text', async (msg) => {
   const user = msg.from as Bot.User
   const messageId = msg.message_id
   const { command, params } = parseFieldsFromMessage(msg.text)
-  const currentTime = getCurrentTime()
-
   switch (command) {
     case '/ida':
     case '/volta':
-      await handleNewRide(command, chatId, messageId, user, currentTime, params)
+      await handleNewRide(command, chatId, messageId, user, new Date(), params)
       break
 
     case '/lotou':
@@ -192,7 +190,7 @@ const listRides = async (chatId: number) =>
       : tgBot.sendMessage(chatId, 'Nenhuma carona cadastrada até o momento.')
   })
 
-const cleanRides = async (chatId: number) => rideManager.cleanRides(chatId, getCurrentTime())
+const cleanRides = async (chatId: number) => rideManager.cleanRides(chatId, new Date())
 
 const handleRemoveRide = async (
   command: string,

--- a/src/rideManager.ts
+++ b/src/rideManager.ts
@@ -2,12 +2,18 @@ import Bot from 'node-telegram-bot-api'
 
 import { Group, Ride } from '../typings/ride'
 
-import { compareValues } from './utils/format.js'
-import { ridesToArray, unsetRides } from './utils/bot.js'
-import { getDifference } from './utils/array.js'
 import { Database } from './database.js'
-import { weekdays, emojis } from './utils/const.js'
+import { getDifference } from './utils/array.js'
+import { ridesToArray, unsetRides } from './utils/bot.js'
+import { emojis, weekdays } from './utils/const.js'
+import {
+  USER_TIME_ZONE,
+  getWeekdayIndexInZone,
+  getZonedParts,
+  zonedDateSortKey
+} from './utils/date.js'
 import * as format from './utils/format.js'
+import { compareValues } from './utils/format.js'
 import { getUserLink } from './utils/messages.js'
 
 export default class RideManager {
@@ -101,11 +107,12 @@ export default class RideManager {
     let rides = ridesToArray(group)
 
     //It sorts by day/month, then direction, then time
+    const tz = USER_TIME_ZONE
     rides.sort((a, b) => {
       return (
         compareValues(
-          new Date(a.time).setHours(0, 0, 0, 0),
-          new Date(b.time).setHours(0, 0, 0, 0)
+          zonedDateSortKey(new Date(a.time), tz),
+          zonedDateSortKey(new Date(b.time), tz)
         ) ||
         compareValues(a.direction, b.direction) ||
         compareValues(new Date(a.time), new Date(b.time))
@@ -114,7 +121,6 @@ export default class RideManager {
 
     // Auxiliary variables
     let message = ''
-    let date, hours, minutes, day, month, weekday
     let previousDirection: string, previousDate: string
     let rideInfo
     let changedDate = false
@@ -122,30 +128,28 @@ export default class RideManager {
     // Assemble the message while iterating over the
     // rides array
     rides.forEach((ride) => {
-      date = new Date(ride.time)
-      hours = date.getHours()
-      minutes = date.getMinutes()
-      day = date.getDate()
-      month = date.getMonth() + 1
-      weekday = weekdays.pt_br[date.getDay()]
+      const when = new Date(ride.time)
+      const z = getZonedParts(when, USER_TIME_ZONE)
+      const weekdayIdx = getWeekdayIndexInZone(when, USER_TIME_ZONE)
 
       // Avoid problems when accessing the user
       if (!ride.user) return
 
       // Check if day/month changed to print a new line
-      if (!previousDate || previousDate !== date.toDateString()) {
+      const dateLineKey = `${z.year}-${z.month}-${z.day}`
+      if (!previousDate || previousDate !== dateLineKey) {
         changedDate = true
         if (previousDate) message += '\n'
         message +=
-          format.getSpecialDayEmoji(day, month) +
+          format.getSpecialDayEmoji(z.day, z.month) +
           '<b>' +
-          format.addZeroPadding(day) +
+          format.addZeroPadding(z.day) +
           '/' +
-          format.addZeroPadding(month) +
+          format.addZeroPadding(z.month) +
           ' - ' +
-          weekday +
+          weekdays.pt_br[weekdayIdx] +
           '</b> ' +
-          emojis[date.getDay()] +
+          emojis[weekdayIdx] +
           '\n'
       }
 
@@ -158,9 +162,9 @@ export default class RideManager {
       // Ride info (time and description)
       rideInfo =
         ' - ' +
-        format.addZeroPadding(hours) +
+        format.addZeroPadding(z.hour) +
         ':' +
-        format.addZeroPadding(minutes) +
+        format.addZeroPadding(z.minute) +
         ' - ' +
         ride.description
 
@@ -180,7 +184,7 @@ export default class RideManager {
       }
 
       previousDirection = ride.direction
-      previousDate = date.toDateString()
+      previousDate = dateLineKey
       changedDate = false
     })
 

--- a/src/utils/bot.ts
+++ b/src/utils/bot.ts
@@ -1,4 +1,5 @@
 import { Group, GroupRides, Ride } from '../../typings/ride.js'
+import { addCalendarDays, brasiliaLocalToUtc, getZonedParts } from './date.js'
 
 export const parseFieldsFromMessage = (message: string) => {
   const [command, ...params] = message.split(' ')
@@ -24,17 +25,19 @@ export const unsetRides = (rides: Ride[]) => {
 }
 
 export const setRideDateAndTime = (now: Date, rideTime: string[], isToday: boolean) => {
-  let rideDateAndTime = new Date()
-  rideDateAndTime.setSeconds(0)
-  rideDateAndTime.setHours(parseInt(rideTime[1]))
+  const { year, month, day } = getZonedParts(now)
+  const hour = parseInt(rideTime[1], 10)
+  const minute = rideTime[2] ? parseInt(rideTime[2], 10) : 0
 
-  rideTime[2] ? rideDateAndTime.setMinutes(parseInt(rideTime[2])) : rideDateAndTime.setMinutes(0)
+  let y = year
+  let mo = month
+  let d = day
 
-  // If the "today" flag is not present and the ride hour/minute is before
-  // the current time.
-  if (!isToday && rideDateAndTime < now) rideDateAndTime.setDate(rideDateAndTime.getDate() + 1)
+  if (!isToday && brasiliaLocalToUtc(y, mo, d, hour, minute).getTime() < now.getTime()) {
+    ;[y, mo, d] = addCalendarDays(y, mo, d, 1)
+  }
 
-  return rideDateAndTime
+  return brasiliaLocalToUtc(y, mo, d, hour, minute)
 }
 
 export const getRideInfo = (params: string[]) => {

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,11 +1,91 @@
 import { timeRegexPattern } from './const.js'
 
-export const getCurrentTime = () => {
-  const d = new Date()
+/** All ride times are interpreted and shown in this zone (users are in Brazil). */
+export const USER_TIME_ZONE = 'America/Sao_Paulo'
 
-  //TODO: Remove hardcoded Brasilia timezone
-  d.setTime(d.getTime() + d.getTimezoneOffset() * 60 * 1000 - 3 * 60 * 60 * 1000)
-  return new Date(d)
+type ZonedParts = {
+  year: number
+  month: number
+  day: number
+  hour: number
+  minute: number
+  second: number
+}
+
+const zonedPartsFormatter = (timeZone: string) =>
+  new Intl.DateTimeFormat('en-CA', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false
+  })
+
+const readPart = (parts: Intl.DateTimeFormatPart[], type: string) =>
+  Number(parts.find((p) => p.type === type)?.value ?? 'NaN')
+
+/** Wall-clock fields for `date` when viewed in `timeZone` (e.g. Brasília). */
+export const getZonedParts = (date: Date, timeZone: string = USER_TIME_ZONE): ZonedParts => {
+  const parts = zonedPartsFormatter(timeZone).formatToParts(date)
+  return {
+    year: readPart(parts, 'year'),
+    month: readPart(parts, 'month'),
+    day: readPart(parts, 'day'),
+    hour: readPart(parts, 'hour'),
+    minute: readPart(parts, 'minute'),
+    second: readPart(parts, 'second')
+  }
+}
+
+/** BRT = UTC−3 (no DST since 2019 in Brazil — revisit if rules change). */
+const BRT_OFFSET_HOURS = 3
+
+/** Civil date/time in Brasília → UTC instant (the `Date` Mongo persists). */
+export const brasiliaLocalToUtc = (
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number
+): Date => new Date(Date.UTC(year, month - 1, day, hour + BRT_OFFSET_HOURS, minute, 0))
+
+/** YYYYMMDD in the user zone — for sorting/grouping by calendar day. */
+export const zonedDateSortKey = (date: Date, timeZone: string = USER_TIME_ZONE): number => {
+  const p = getZonedParts(date, timeZone)
+  return p.year * 10000 + p.month * 100 + p.day
+}
+
+const EN_WEEKDAY_LONG = [
+  'Sunday',
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday'
+] as const
+
+/** 0 = Sunday … 6 = Saturday, for the civil calendar day containing `date` in `timeZone`. */
+export const getWeekdayIndexInZone = (date: Date, timeZone: string = USER_TIME_ZONE): number => {
+  const w = new Intl.DateTimeFormat('en-US', { timeZone, weekday: 'long' }).formatToParts(date)
+  const label = w.find((p) => p.type === 'weekday')?.value
+  const idx = EN_WEEKDAY_LONG.indexOf(label as (typeof EN_WEEKDAY_LONG)[number])
+  if (idx < 0) throw new Error(`Unexpected weekday label: ${label}`)
+  return idx
+}
+
+/** Gregorian calendar (y, m, d) plus `deltaDays` — same calendar Brazil uses. */
+export const addCalendarDays = (
+  year: number,
+  month: number,
+  day: number,
+  deltaDays: number
+): [number, number, number] => {
+  const x = new Date(Date.UTC(year, month - 1, day + deltaDays))
+  return [x.getUTCFullYear(), x.getUTCMonth() + 1, x.getUTCDate()]
 }
 
 export const validateTimeFormat = (time: string) => {


### PR DESCRIPTION
After migrating the bot to a new deployment, we faced issues with interpreting the timezones. This PR fixes the problems we were facing by correctly storing the dates in UTC timezone, but converting them back to display to the users.